### PR TITLE
Liquidation slippages

### DIFF
--- a/src/controller.lua
+++ b/src/controller.lua
@@ -577,6 +577,16 @@ Handlers.add(
         expectedRewardQty = availableRewardQty
       end
 
+      -- the minimum quantity expected by the user
+      local minExpectedRewardQty = bint(msg.Tags["X-Min-Expected-Quantity"] or 0)
+
+      -- make sure the user is receiving at least
+      -- the minimum amount of tokens they're expecting
+      assert(
+        bint.ule(minExpectedRewardQty, expectedRewardQty),
+        "Could not meet the defined slippage"
+      )
+
       -- check liquidation queue again
       -- in case a liquidation has been queued
       -- while fetching positions


### PR DESCRIPTION
This PR adds support for liquidation slippages, which allows the liquidator to define the minimum expected quantity of reward tokens for a liquidation. If the defined qty is more than they would receive, the liquidation fails.
The only extra tag this requires is `X-Min-Expected-Quantity` in the liquidation `Transfer` message.